### PR TITLE
implement dependent svelecte work for make, model and year

### DIFF
--- a/src/routes/api/[makeId]/modelsbymake.svelte
+++ b/src/routes/api/[makeId]/modelsbymake.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-	import { getModelsByMakeId, vechile } from "$lib/store";
+	import { getModelsByMakeId } from "$lib/store";
 
 	
 	export async function load(params) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,9 +1,6 @@
 <script context="module">
-	import { addFormatter, config, registerSvelecte } from 'svelecte/component.js';
   	import Svelecte from "svelecte";
-	registerSvelecte('el-svelecte');
 
-  
 	let payload = null;
 
 	function onSubmit(e) {
@@ -51,9 +48,32 @@
 		Make_value = value;
 	});
 
+	/**
+	 * NOTE: I am comparing store values to text 'null', because you store it in localStorage.
+	 * That should be fixed in $lib/store.js in your export function
+	 * 
+	 * I am using real API endpoints I found in your code to be able to test it properly.
+	 * */ 
+	$: model_fetchUrl = $Make && $Make !== 'null'
+		? `https://api.findcar.parts/api/rest/make/${$Make}/models`
+		: null;
+	$: year_fetchUrl = $Model && $Model !== 'null'
+		? `https://api.findcar.parts/api/rest/make/${$Make}/models/${$Model}`
+		: null;
+
+	/**
+	 * Resolve 'items' property from response correctly
+	 * @param resp
+	 */
+	function onFetch(resp) {
+		if (resp.uvdb.search_uvdb_models) 
+			return resp.uvdb.search_uvdb_models.items;
+		if (resp.uvdb.search_uvdb_years) 
+			return resp.uvdb.search_uvdb_years.items;
+	};
 
 </script>
-
+<!--
 <form action="" on:submit|preventDefault={onSubmit}>
 	<el-svelecte 
 			name="make" placeholder="make"
@@ -82,41 +102,40 @@
 	  <pre>{payload}</pre>
 	{/if}
   </form>
-
-<!-- <form action="" on:submit|preventDefault={onSubmit} class="basic-attrib sm:flex-none md:flex justify-center">
+-->
+<form action="" on:submit|preventDefault={onSubmit} class="basic-attrib sm:flex-none md:flex justify-center">
 	<div class="flex-1 car-attrib">
 	  <Svelecte bind:value={$Make}
-		name="parent_value" placeholder="make"
-		searchable=True
-		clearable=True
+		name="make" placeholder="make"
+		clearable
 		options={makes}
-		
 	  >
-
 	  </Svelecte>
 	</div>
 	<div class="flex-1 car-attrib">
 	  <Svelecte bind:value={$Model}
-		name="child_value" parent="parent" required placeholder="model"
-		searchable=True
-		clearable=True
-		options={Model}
-		id="model"
-		fetch="/api/[parent]">
-		
-	  </Svelecte>
+			disabled={!model_fetchUrl}
+			name="model"
+			required placeholder="model"
+			clearable
+			id="model"
+			fetch={model_fetchUrl}
+			fetchCallback={onFetch}
+		></Svelecte>
 	</div>
 	<div class="flex-1 car-attrib">  
 	  <Svelecte 
-		name="child_value" parent="model"
+		disabled={!year_fetchUrl}
+		fetch={year_fetchUrl}
+		fetchCallback={onFetch}
+		name="year"
 		required placeholder="year"
-		fetch="/api/{Model}/models/[parent]"
-		searchable=True
-		clearable=True
+		clearable
 		id="year"
 		>
 	  </Svelecte>
 	</div>
+<!--
 	<div class="flex-1 car-attrib ">
 	  <Svelecte bind:value={$Make}
 		name="parent_value" placeholder="submodels"
@@ -127,8 +146,8 @@
 		id="is-parent" required>
 	  </Svelecte>
 	</div> 
+-->
 	{#if payload}
 	<pre>{payload}</pre>
   {/if}
 </form>
- -->


### PR DESCRIPTION
Working example of 3 svelectes, where every one depends on the svelecte before with some explaining comments.

Because you are creating pure Svelte application, you shouldn't use `import { registerSvelecte } from 'svelecte/component'`. You need to implement dependent selects "manually" as I did in the code.

_Just a sidenote: had to remove `vechile` from `modelsbymake.svelte` because it prevented app from running_

PS: if you want to keep the repo private, you can invite me as a colaborator.